### PR TITLE
Return Result from methods vs panicking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = { version = "1.0.100", optional = true }
 strum = { version = "0.25.0", optional = true }
 strum_macros = { version = "0.25.1", optional = true }
 futures = { version = "0.3.28", optional = true }
+itertools = { version = "0.11.0", optional = true }
 
 [dev-dependencies]
 rstest = "0.18.1"
@@ -25,7 +26,13 @@ once_cell = "1.18.0"
 
 [features]
 xml = ["dep:serde-xml-rs"]
-json = ["dep:serde_json", "dep:strum", "dep:strum_macros", "dep:futures"]
+json = [
+    "dep:serde_json",
+    "dep:strum",
+    "dep:strum_macros",
+    "dep:futures",
+    "dep:itertools"
+]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client-3dsdb"
-version = "0.4.0"
+version = "1.0.0"
 edition = "2021"
 description = "A Rust client for 3DS title DBs."
 repository = "https://github.com/Lewis-Trowbridge/client-3dsdb"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,18 @@
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug, Clone)]
+pub struct Error {
+    pub(crate) message: String
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl From<reqwest::Error> for Error {
+    fn from(value: reqwest::Error) -> Self {
+        Error { message: value.to_string() }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,16 @@
+//! Custom errors.
+//!
+//! A small module that contains a custom error struct used to encapsulate errors from lower down in
+//! the function call chain.
+//!
+
+
 use std::fmt::{Display, Formatter};
 
+/// A custom error struct. Contains the string representation for the encapsulated error.
 #[derive(Debug, Clone)]
 pub struct Error {
-    pub(crate) message: String
+    pub message: String
 }
 
 impl Display for Error {

--- a/src/json.rs
+++ b/src/json.rs
@@ -35,7 +35,7 @@ use serde::Deserialize;
 use strum_macros::{Display, EnumIter};
 use strum::IntoEnumIterator;
 use rayon::prelude::*;
-use reqwest::Error;
+use crate::error::Error;
 
 /// A title region. Required to access region-specific title lists.
 #[derive(Display, Debug, EnumIter)]
@@ -82,7 +82,10 @@ pub async fn get_releases_async(region: Region) -> Vec<Release> {
 /// Gets [Release]s synchronously for a given region.
 pub fn get_releases(region: Region) -> Result<Vec<Release>, Error> {
     let request = reqwest::blocking::get(&format!("https://raw.githubusercontent.com/hax0kartik/3dsdb/master/jsons/list_{}.json", region))?;
-    request.json()
+    match request.json() {
+        Ok(releases) => Ok(releases),
+        Err(error) => Err(Error::from(error))
+    }
 }
 
 /// Gets a hash map of [Release]s with title IDs as the key.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@
 //! - xml: <http://3dsdb.com>
 //! - json: <https://github.com/hax0kartik/3dsdb>
 
+pub mod error;
+
 #[cfg(feature = "xml")]
 pub mod xml;
 #[cfg(feature = "json")]

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -101,7 +101,7 @@ pub fn get_releases_map() -> Result<HashMap<String, Release>, Error> {
 
 impl From<serde_xml_rs::Error> for Error {
     fn from(value: serde_xml_rs::Error) -> Self {
-        Error { message: format!("{:?}", value) }
+        Error { message: format!("{}", value) }
     }
 }
 

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -68,17 +68,17 @@ pub struct Release {
 }
 
 /// Gets of [Release]s asynchronously.
-pub async fn get_releases_async() -> Vec<Release> {
-    let request = reqwest::get("http://3dsdb.com/xml.php").await.unwrap();
-    let release: Releases = serde_xml_rs::from_str(&request.text().await.unwrap()).unwrap();
-    release.releases
+pub async fn get_releases_async() -> Result<Vec<Release>, Error> {
+    let response = reqwest::get("http://3dsdb.com/xml.php").await?;
+    let text = response.text().await?;
+    let release: Releases = serde_xml_rs::from_str(&text)?;
+    Ok(release.releases)
 }
 
 /// Gets [Release]s synchronously.
 pub fn get_releases() -> Result<Vec<Release>, Error> {
-    let request = reqwest::blocking::get("http://3dsdb.com/xml.php")?;
-    let text = request.text()?;
-    let release: Releases = serde_xml_rs::from_str(&text)?;
+    let response = reqwest::blocking::get("http://3dsdb.com/xml.php")?;
+    let release: Releases = serde_xml_rs::from_reader(response)?;
     Ok(release.releases)
 
 }
@@ -140,7 +140,7 @@ mod tests {
 
     #[rstest]
     async fn get_releases_async_gets_valid_information() {
-        let value = get_releases_async().await;
+        let value = get_releases_async().await.unwrap();
         let actual = value.get(0).unwrap();
         assert_eq!(actual, EXPECTED_RELEASE.deref())
     }

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -8,7 +8,7 @@
 //! use client_3dsdb::xml::get_releases;
 //!
 //! fn print_releases() {
-//!     let releases = get_releases();
+//!     let releases = get_releases().unwrap();
 //!
 //!     for release in releases {
 //!         println!("{}", release.name);
@@ -22,15 +22,17 @@
 //! ```
 //! use client_3dsdb::xml::get_releases_map;
 //!
-//! let releases = get_releases_map();
+//! let releases = get_releases_map().unwrap();
 //! let a_great_game = releases.get("0004000000030200").unwrap();
 //! assert_eq!(a_great_game.name, "Kid Icarus: Uprising")
 //! ```
 //!
 
 use std::collections::HashMap;
+use std::fmt::Debug;
 use serde::Deserialize;
 use rayon::prelude::*;
+use crate::error::Error;
 
 #[derive(Deserialize)]
 struct Releases {
@@ -73,10 +75,12 @@ pub async fn get_releases_async() -> Vec<Release> {
 }
 
 /// Gets [Release]s synchronously.
-pub fn get_releases() -> Vec<Release> {
-    let request = reqwest::blocking::get("http://3dsdb.com/xml.php").unwrap();
-    let release: Releases = serde_xml_rs::from_str(&request.text().unwrap()).unwrap();
-    release.releases
+pub fn get_releases() -> Result<Vec<Release>, Error> {
+    let request = reqwest::blocking::get("http://3dsdb.com/xml.php")?;
+    let text = request.text()?;
+    let release: Releases = serde_xml_rs::from_str(&text)?;
+    Ok(release.releases)
+
 }
 
 /// Gets a hash map of [Release]s with title IDs as the key.
@@ -84,15 +88,21 @@ pub fn get_releases() -> Vec<Release> {
 /// ```
 /// use client_3dsdb::xml::get_releases_map;
 ///
-/// let releases = get_releases_map();
+/// let releases = get_releases_map().unwrap();
 /// let a_great_game = releases.get("0004000000030200").unwrap();
 /// assert_eq!(a_great_game.name, "Kid Icarus: Uprising")
 /// ```
-pub fn get_releases_map() -> HashMap<String, Release> {
-    get_releases()
-        .into_par_iter()
+pub fn get_releases_map() -> Result<HashMap<String, Release>, Error> {
+    let releases = get_releases()?;
+    Ok(releases.into_par_iter()
         .map(|release| (release.title_id.clone(), release))
-        .collect()
+        .collect())
+}
+
+impl From<serde_xml_rs::Error> for Error {
+    fn from(value: serde_xml_rs::Error) -> Self {
+        Error { message: format!("{:?}", value) }
+    }
 }
 
 #[cfg(test)]
@@ -123,7 +133,7 @@ mod tests {
 
     #[rstest]
     fn get_releases_gets_valid_information() {
-        let value = get_releases();
+        let value = get_releases().unwrap();
         let actual = value.get(0).unwrap();
         assert_eq!(actual, EXPECTED_RELEASE.deref())
     }
@@ -137,7 +147,7 @@ mod tests {
 
     #[rstest]
     fn get_releases_map_gets_valid_information() {
-        let releases_map = get_releases_map();
+        let releases_map = get_releases_map().unwrap();
         let actual = releases_map.get(&EXPECTED_RELEASE.title_id).unwrap();
         assert_eq!(actual, EXPECTED_RELEASE.deref())
     }


### PR DESCRIPTION
This PR alters all methods to allow for proper error handling using Rust's Result struct. Because this is a breaking change, this marks version 1.0.0. At this point, the library can be considered somewhat complete, although some extra features, fixes and documentation may continue to be added over time.